### PR TITLE
Fix formal checker

### DIFF
--- a/.github/workflows/ci-rewards-checker.yml
+++ b/.github/workflows/ci-rewards-checker.yml
@@ -9,6 +9,7 @@ on:
       - "distribution/**"
       - "test-forge/**"
       - ".github/workflows/ci-rewards-checker.yml"
+      - "foundry.toml"
 
 concurrency:
   group: ci-rewards-checker-${{ github.ref }}

--- a/foundry.toml
+++ b/foundry.toml
@@ -2,3 +2,4 @@
 test = 'test-forge'
 fs_permissions = [{access = "read", path= "./"}]
 match_contract = 'CheckerTest'
+gas_limit = "18446744073709551615" # 2^64 - 1, to remove the gas limit


### PR DESCRIPTION
Removes the gas limit, to fix the checker since the following update of forge:
- https://github.com/foundry-rs/foundry/pull/8274

In case of the checker we are only using forge's runtime for checking functional correctness, so the gas limit is useless.

See for example [this job](https://github.com/morpho-org/morpho-optimizers-rewards/actions/runs/10142751769/job/28050191458)